### PR TITLE
Fix Nashorn loading on Java 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Include dependencies and plugin in pom.xml, and place copybook definition files 
         <plugin>
             <groupId>com.nordea.oss</groupId>
             <artifactId>copybook4java-codegen-maven-plugin</artifactId>
-            <version>1.0.5</version>
+            <version>1.0.6</version>
             <configuration>
                 <inputFilter>^.*\.txt$</inputFilter>
                 <inputPath>src/test/resources/</inputPath>

--- a/copybook4java-codegen-maven-plugin/pom.xml
+++ b/copybook4java-codegen-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.nordea.oss</groupId>
     <artifactId>copybook4java-codegen-maven-plugin</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/copybook4java-codegen-maven-plugin/src/main/java/com/nordea/oss/copybook/codegen/CopyBookConverter.java
+++ b/copybook4java-codegen-maven-plugin/src/main/java/com/nordea/oss/copybook/codegen/CopyBookConverter.java
@@ -29,7 +29,7 @@ public class CopyBookConverter {
         InputStream inputStream = this.getClass().getResourceAsStream("classconverter.html");
         String js = extractJS(inputStream);
 
-        manager = new ScriptEngineManager();
+        manager = new ScriptEngineManager(null);
         engine = manager.getEngineByName("nashorn");
 
         if(engine == null) {

--- a/copybook4java-codegen-maven-test/pom.xml
+++ b/copybook4java-codegen-maven-test/pom.xml
@@ -31,7 +31,7 @@
             <plugin>
                 <groupId>com.nordea.oss</groupId>
                 <artifactId>copybook4java-codegen-maven-plugin</artifactId>
-                <version>1.0.5</version>
+                <version>1.0.6</version>
                 <configuration>
                     <inputFilter>^.*\.txt$</inputFilter>
                     <inputPath>src/test/resources/</inputPath>


### PR DESCRIPTION
The current version of copybook4java maven plugin fails on code generation step using Java 9, because the Nashorn could not be found.
This small change fixes that without any impact on using with previous Java versions.