### PR TITLE
Make it compatible with JDK 11

### DIFF
--- a/copybook4java-codegen-maven-plugin/pom.xml
+++ b/copybook4java-codegen-maven-plugin/pom.xml
@@ -40,6 +40,17 @@
             </roles>
             <timezone>Europe/Copenhagen</timezone>
         </developer>
+        <developer>
+            <id>madsum</id>
+            <name>masum islam</name>
+            <email>masum.islam@consult.nordea.com</email>
+            <organization>Nordea Bank AB</organization>
+            <organizationUrl>http://www.nordea.com</organizationUrl>
+            <roles>
+                <role>developer</role>
+            </roles>
+            <timezone>Europe/Helsinki</timezone>
+        </developer>
     </developers>
 
     <ciManagement>
@@ -173,7 +184,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
+                        <version>3.2.0</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -223,6 +234,11 @@
             <version>1.0.3</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.3</version>
+        </dependency>
         <!-- maven stuff : https://blog.sagaoftherealms.net/?p=528 , https://github.com/jcabi/jcabi-maven-plugin/blob/master/pom.xml-->
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/copybook4java-codegen-maven-plugin/src/main/java/com/nordea/oss/copybook/codegen/CopyBookConverter.java
+++ b/copybook4java-codegen-maven-plugin/src/main/java/com/nordea/oss/copybook/codegen/CopyBookConverter.java
@@ -7,7 +7,7 @@
 package com.nordea.oss.copybook.codegen;
 
 import com.nordea.oss.ByteUtils;
-import jdk.nashorn.api.scripting.ScriptObjectMirror;
+import org.openjdk.nashorn.api.scripting.ScriptObjectMirror;
 
 import javax.script.*;
 import java.io.*;

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,16 @@
         <module>copybook4java-codegen-maven-plugin</module>
         <module>copybook4java-codegen-maven-test</module>
     </modules>
+    <scm>
+        <connection>scm:git:git://github.com/openjdk/nashorn.git</connection>
+        <developerConnection>scm:git:ssh://github.com:openjdk/nashorn.git</developerConnection>
+        <url>http://github.com/openjdk/nashorn/tree/main</url>
+    </scm>
+
+    <properties>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+    </properties>
 
     <build>
         <plugins>
@@ -32,6 +42,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.openjdk.nashorn</groupId>
+                <artifactId>nashorn-core</artifactId>
+                <version>15.2</version>
+            </dependency>
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>


### PR DESCRIPTION
I am trying to make copybook4java to java 11. Child project copybook4java-codegen-maven-test fails when tried mvn clean install for 

Failed to execute goal org.apache.maven.plugins:maven-plugin-plugin:3.4:descriptor (defaul

Hopefully. it is something minor to fix for you. 
