### PR TITLE
Migrate to Java 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk17
 
 branches:
   only:

--- a/copybook4java-codegen-maven-plugin/pom.xml
+++ b/copybook4java-codegen-maven-plugin/pom.xml
@@ -4,12 +4,12 @@
 
     <groupId>com.nordea.oss</groupId>
     <artifactId>copybook4java-codegen-maven-plugin</artifactId>
-    <version>1.0.6</version>
+    <version>1.2.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.version>3.3.9</maven.version>
-        <maven.plugin.version>3.4</maven.plugin.version>
+        <maven.version>3.8.7</maven.version>
+        <maven.plugin.version>3.7.1</maven.plugin.version>
     </properties>
 
     <packaging>maven-plugin</packaging>
@@ -83,8 +83,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                     <compilerArgument>-Xlint:all</compilerArgument>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
@@ -93,7 +93,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.3</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18</version>
+                <version>2.22.2</version>
                 <configuration>
                     <parallel>methods</parallel>
                     <threadCount>10</threadCount>
@@ -112,7 +112,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-scm-plugin</artifactId>
-                <version>1.8.1</version>
+                <version>1.13.0</version>
                 <configuration>
                     <tag>v${project.version}</tag>
                 </configuration>
@@ -120,7 +120,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.1</version>
+                <version>2.14.2</version>
                 <configuration>
                     <generateBackupPoms>false</generateBackupPoms>
                 </configuration>
@@ -186,7 +186,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9.1</version>
+                        <version>2.10.4</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -199,7 +199,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -221,6 +221,13 @@
             <groupId>com.nordea.oss</groupId>
             <artifactId>copybook4java</artifactId>
             <version>1.0.3</version>
+        </dependency>
+
+        <!-- generation engine -->
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.4</version>
         </dependency>
 
         <!-- maven stuff : https://blog.sagaoftherealms.net/?p=528 , https://github.com/jcabi/jcabi-maven-plugin/blob/master/pom.xml-->

--- a/copybook4java-codegen-maven-plugin/src/main/java/com/nordea/oss/copybook/codegen/CopyBookConverter.java
+++ b/copybook4java-codegen-maven-plugin/src/main/java/com/nordea/oss/copybook/codegen/CopyBookConverter.java
@@ -7,7 +7,7 @@
 package com.nordea.oss.copybook.codegen;
 
 import com.nordea.oss.ByteUtils;
-import jdk.nashorn.api.scripting.ScriptObjectMirror;
+import org.openjdk.nashorn.api.scripting.ScriptObjectMirror;
 
 import javax.script.*;
 import java.io.*;
@@ -29,7 +29,7 @@ public class CopyBookConverter {
         InputStream inputStream = this.getClass().getResourceAsStream("classconverter.html");
         String js = extractJS(inputStream);
 
-        manager = new ScriptEngineManager(null);
+        manager = new ScriptEngineManager();
         engine = manager.getEngineByName("nashorn");
 
         if(engine == null) {

--- a/copybook4java-codegen-maven-plugin/src/test/java/com/nordea/oss/copybook/codegen/JavaSyntaxChecker.java
+++ b/copybook4java-codegen-maven-plugin/src/test/java/com/nordea/oss/copybook/codegen/JavaSyntaxChecker.java
@@ -38,7 +38,7 @@ public class JavaSyntaxChecker {
 
         StandardJavaFileManager fileManager = javac.getStandardFileManager(null, null, StandardCharsets.UTF_8);
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
-        JavaCompiler.CompilationTask task = javac.getTask(null, new InMemmoryFileManager(javac.getStandardFileManager(null, null, null)), diagnostics, null, null, stringSourceCodes);
+        JavaCompiler.CompilationTask task = javac.getTask(null, new InMemoryFileManager(fileManager), diagnostics, null, null, stringSourceCodes);
         task.call();
 
         List<String> errors = new ArrayList<>();
@@ -62,11 +62,11 @@ public class JavaSyntaxChecker {
         }
     }
 
-    private static class InMemmoryFileManager implements JavaFileManager {
+    private static class InMemoryFileManager implements JavaFileManager {
         private final StandardJavaFileManager fileManager;
         private final Map<String, ByteArrayOutputStream> buffers = new LinkedHashMap<>();
 
-        InMemmoryFileManager(StandardJavaFileManager fileManager) {
+        InMemoryFileManager(StandardJavaFileManager fileManager) {
             this.fileManager = fileManager;
         }
 
@@ -125,7 +125,7 @@ public class JavaSyntaxChecker {
             return fileManager.getFileForOutput(location, packageName, relativeName, sibling);
         }
 
-        public void flush() throws IOException {
+        public void flush() {
             // Do nothing
         }
 
@@ -136,6 +136,13 @@ public class JavaSyntaxChecker {
         public int isSupportedOption(String option) {
             return fileManager.isSupportedOption(option);
         }
-    }
 
+        public String inferModuleName(Location location) throws IOException {
+            return fileManager.inferModuleName(location);
+        }
+
+        public Iterable<Set<Location>> listLocationsForModules(Location location) throws IOException {
+            return fileManager.listLocationsForModules(location);
+        }
+    }
 }

--- a/copybook4java-codegen-maven-test/pom.xml
+++ b/copybook4java-codegen-maven-test/pom.xml
@@ -19,10 +19,10 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                     <compilerArgument>-Xlint:all</compilerArgument>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>true</showDeprecation>
@@ -31,7 +31,7 @@
             <plugin>
                 <groupId>com.nordea.oss</groupId>
                 <artifactId>copybook4java-codegen-maven-plugin</artifactId>
-                <version>1.0.6</version>
+                <version>1.2.0</version>
                 <configuration>
                     <inputFilter>^.*\.txt$</inputFilter>
                     <inputPath>src/test/resources/</inputPath>


### PR DESCRIPTION
This PR introduces a new `copybook4java-codegen-maven-plugin` version that uses Java 17 as Java 11 LTS support ends in September 2023: https://www.oracle.com/java/technologies/java-se-support-roadmap.html
Nashorn was removed from JDK 15, therefore we include its dependency explicitly.